### PR TITLE
fix: Edit the way of CMS content fetching

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,21 +6,24 @@ import Resume from "./Pages/Resume";
 import NotFound from "./Pages/NotFound";
 
 import { HashRouter as Router, Route, Routes } from "react-router-dom";
+import { AppDataProvider } from "./Contexts/AppDataProvider";
 
 const App = () => {
   return (
     <>
-      <Router>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route path="/" element={<Home />} />
-            <Route path="/projects" element={<Projects />} />
-            <Route path="/projects/:id" element={<ProjectDetail />} />
-            <Route path="/resume" element={<Resume />} />
-            <Route path="*" element={<NotFound />} />
-          </Route>
-        </Routes>
-      </Router>
+      <AppDataProvider>
+        <Router>
+          <Routes>
+            <Route element={<Layout />}>
+              <Route path="/" element={<Home />} />
+              <Route path="/projects" element={<Projects />} />
+              <Route path="/projects/:id" element={<ProjectDetail />} />
+              <Route path="/resume" element={<Resume />} />
+              <Route path="*" element={<NotFound />} />
+            </Route>
+          </Routes>
+        </Router>
+      </AppDataProvider>
     </>
   );
 };

--- a/client/src/Contexts/AppDataProvider.jsx
+++ b/client/src/Contexts/AppDataProvider.jsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+import useSWR from "swr";
+import { fetchAppData } from "../utils/contentful";
+
+const AppDataContext = createContext();
+
+export const AppDataProvider = ({ children }) => {
+  const { data: appData, error, isLoading } = useSWR("appData", fetchAppData);
+
+  return (
+    <AppDataContext.Provider value={{ appData, error, isLoading }}>
+      {children}
+    </AppDataContext.Provider>
+  );
+};
+
+export const useAppData = () => {
+  const context = useContext(AppDataContext);
+  if (!context) {
+    throw new Error("useAppData must be used within AppDataProvider");
+  }
+  return context;
+};

--- a/client/src/Pages/Home.jsx
+++ b/client/src/Pages/Home.jsx
@@ -1,8 +1,18 @@
 import Position from "../Components/Position";
 import { FaGithub, FaLinkedin } from "react-icons/fa";
 import { motion } from "framer-motion";
+import { useAppData } from "../Contexts/AppDataProvider";
+import LoadingSpinner from "../Components/Loading";
+import ErrorMessage from "../Components/ErrorMessage";
 
 const Home = () => {
+  const { appData, error, isLoading } = useAppData();
+  if (isLoading) return <LoadingSpinner />;
+  if (error) return <ErrorMessage />;
+
+  if (!appData) return <LoadingSpinner />;
+
+
   return (
     <div className="px-10">
       <div className="flex sm:flex-row flex-col-reverse text-[45px] justify-between items-center gap-1">
@@ -35,11 +45,7 @@ const Home = () => {
           Let me <span className="text-fuchsia-500">introduce</span> myself
         </h2>
         <p className="text-[18px] sm:text-[25px]">
-          I’m an experienced software developer with over 5 years delivering
-          2D/3D and VR/AR interactive applications using Unity and C#. Currently
-          growing my expertise in back-end and full-stack development, focusing
-          on ASP.NET Core and React. I thrive on solving complex challenges,
-          building modern web apps, and learning new things along the way.
+          {appData.introduction}
         </p>
       </motion.div>
 
@@ -53,12 +59,7 @@ const Home = () => {
           Beyond <span className="text-fuchsia-500">code</span>
         </h2>
         <p className="text-[18px] sm:text-[25px]">
-          When I’m not coding, you’ll find me playing soccer, cycling around the
-          city, or enjoying video games. I also spend time learning guitar,
-          experimenting with 3D printing, and exploring the world of flying
-          drones. I love hands-on hobbies and am always up for discovering
-          something new, whether it’s mastering a musical riff or piloting the
-          latest drone.
+         {appData.beyondCode}
         </p>
       </motion.div>
 

--- a/client/src/Pages/Projects.jsx
+++ b/client/src/Pages/Projects.jsx
@@ -1,45 +1,44 @@
 import ProjectCard from "../Components/ProjectCard";
-import useSWR from "swr";
-import { fetchProjects } from "../utils/contentful";
 import LoadingSpinner from "../Components/Loading";
 import ErrorMessage from "../Components/ErrorMessage";
 import { motion } from "framer-motion";
+import { useAppData } from "../Contexts/AppDataProvider";
 
 const Projects = () => {
-  const {
-    data: projects,
-    error,
-    isLoading,
-  } = useSWR("projects", fetchProjects);
+  const { appData, error, isLoading } = useAppData();
+  const projects = appData?.projects || [];
 
   if (isLoading) return <LoadingSpinner />;
   if (error) return <ErrorMessage />;
 
   return (
-     <div className="flex flex-wrap gap-6 justify-center">
-    {projects &&
-      projects
-        .slice()
-        .sort((a, b) => {
-          if (typeof a.projectId === "number" && typeof b.projectId === "number") {
-            return a.projectId - b.projectId;
-          }
-          return a.projectId.toString().localeCompare(b.projectId.toString());
-        })
-        .map((project, idx) => (
-          <motion.div
-            key={project.id}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{
-              duration: 0.7,
-              delay: idx * 0.2,
-            }}
-          >
-            <ProjectCard {...project} />
-          </motion.div>
-        ))}
-  </div>
+    <div className="flex flex-wrap gap-6 justify-center">
+      {projects &&
+        projects
+          .slice()
+          .sort((a, b) => {
+            if (
+              typeof a.projectId === "number" &&
+              typeof b.projectId === "number"
+            ) {
+              return a.projectId - b.projectId;
+            }
+            return a.projectId.toString().localeCompare(b.projectId.toString());
+          })
+          .map((project, idx) => (
+            <motion.div
+              key={project.id}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{
+                duration: 0.7,
+                delay: idx * 0.2,
+              }}
+            >
+              <ProjectCard {...project} />
+            </motion.div>
+          ))}
+    </div>
   );
 };
 

--- a/client/src/utils/contentful.js
+++ b/client/src/utils/contentful.js
@@ -1,30 +1,72 @@
-import { createClient } from 'contentful';
+import { createClient } from "contentful";
 
 const client = createClient({
   space: import.meta.env.VITE_CONTENTFUL_SPACE_ID,
-  accessToken: import.meta.env.VITE_CONTENTFUL_ACCESS_TOKEN
+  accessToken: import.meta.env.VITE_CONTENTFUL_ACCESS_TOKEN,
 });
 
+export async function fetchAppData() {
+  try {
+    const entries = await client.getEntries({
+      content_type: "mainApplication",
+      limit: 1,
+    });
+    const appEntry = entries.items[0];
+    console.log(appEntry);
+
+    if (!appEntry) return null;
+
+    const fields = appEntry.fields;
+
+    return {
+      title: fields.applicationTitle,
+      profilePhoto: fields.profilePhoto
+        ? "https:" + fields.profilePhoto.fields.file.url
+        : null,
+      positions: fields.positions || [],
+      introduction: fields.introduction,
+      beyondCode: fields.beyondCode,
+
+      projects:
+        fields.projects?.map((project) => ({
+          id: project.sys.id,
+          projectId: project.fields.id,
+          title: project.fields.title,
+          technologies: project.fields.technologies,
+          description: project.fields.description,
+          shortDescription: project.fields.shortDescription,
+          image: project.fields.image
+            ? "https:" + project.fields.image.fields.file.url
+            : null,
+          imageAltTitle: project.fields.altTitle,
+          link: project.fields.link,
+          gitLink: project.fields.gitLink,
+        })) || [],
+
+      resumeUrl: fields.resume?.fields?.file?.url
+        ? "https:" + fields.resume.fields.file.url
+        : null,
+
+      skills:
+        fields.skills?.map((skill) => ({
+          skillEntry: skill.fields.skillEntry,
+          skillIcon: skill.fields.skillIcon
+            ? "https:" + skill.fields.skillIcon.fields.file.url
+            : null,
+        })) || [],
+    };
+  } catch (error) {
+    console.error("Error fetching app data:", error);
+    throw error;
+  }
+}
+
 export async function fetchProjects() {
-  const entries = await client.getEntries({ content_type: 'project' });
-  return entries.items.map(item => ({
-    id: item.sys.id,
-    projectId: item.fields.id,
-    title: item.fields.title,
-    technologies: item.fields.technologies,
-    description: item.fields.description,
-    shortDescription: item.fields.shortDescription,
-    image: item.fields.image
-      ? 'https:' + item.fields.image.fields.file.url
-      : null,
-    imageAltTitle: item.fields.altTitle,
-    link: item.fields.link,
-    gitLink: item.fields.gitLink,
-  }));
+  const appData = await fetchAppData();
+  return appData?.projects || [];
 }
 
 export async function fetchResumePDF() {
-  const entries = await client.getEntries({ content_type: 'resume' });
-  const pdfFile = entries.items[0]?.fields?.resume;
-  return pdfFile ? 'https:' + pdfFile.fields.file.url : null;
+  const appData = await fetchAppData();
+  return appData?.resumeUrl || null;
 }


### PR DESCRIPTION
## Problem
Previously, the app made separate API calls to fetch projects and resume data from Contentful, which was inefficient and made content management more complex.

# Solution
Refactored to use a single `MainApplication` content type in Contentful that contains all app data:
- Created centralized `fetchAppData()` function that fetches everything in one API call
- Maintained backward compatibility with existing `fetchProjects()` and `fetchResumePDF()` functions

## Technical Changes
- **Updated**: `contentful.js` - Fixed API method usage and response handling
- **Added**: React Context (`AppDataProvider`) for sharing data across components
- **Modified**: Components now use `useAppData()` hook instead of individual fetch calls

## Benefits
- ✅ Single API call instead of multiple requests
- ✅ Better content management in Contentful CMS
- ✅ Improved performance and data consistency
- ✅ Easier to add new fields in the future