### PR TITLE
fix: Resume fetching updated and Positions

### DIFF
--- a/client/src/Components/Position.jsx
+++ b/client/src/Components/Position.jsx
@@ -1,10 +1,10 @@
 import Typewriter from "typewriter-effect";
 
-const Position = () => {
+const Position = ({ positions }) => {
   return (
     <Typewriter 
       options={{
-        strings: [
+        strings: positions || [
           "Software Developer",
           "Product Software Engineer",
           "Interactive Developer",

--- a/client/src/Pages/Home.jsx
+++ b/client/src/Pages/Home.jsx
@@ -25,7 +25,7 @@ const Home = () => {
             </strong>
           </h1>
           <div className="text-fuchsia-500 font-bold pt-5 text-[30px] sm:text-[45px]">
-            <Position />
+            <Position positions= {appData.positions}/>
           </div>
         </div>
         <img

--- a/client/src/Pages/Resume.jsx
+++ b/client/src/Pages/Resume.jsx
@@ -1,17 +1,12 @@
-import { useEffect, useState } from "react";
-import { fetchResumePDF } from "../utils/contentful";
 import LoadingSpinner from "../Components/Loading";
+import { useAppData } from "../Contexts/AppDataProvider";
 
 const Resume = () => {
-  const [pdfUrl, setPdfUrl] = useState(null);
+  const { appData, error, isLoading } = useAppData();
+  const pdfUrl = appData?.resumeUrl;
 
-  useEffect(() => {
-    fetchResumePDF().then(setPdfUrl);
-  }, []);
-
-  if (!pdfUrl) {
-    return <LoadingSpinner />;
-  }
+  if (isLoading) return <LoadingSpinner />;
+  if (error) return <ErrorMessage />;
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-8 bg-transparent">

--- a/client/src/utils/contentful.js
+++ b/client/src/utils/contentful.js
@@ -12,7 +12,6 @@ export async function fetchAppData() {
       limit: 1,
     });
     const appEntry = entries.items[0];
-    console.log(appEntry);
 
     if (!appEntry) return null;
 
@@ -43,10 +42,10 @@ export async function fetchAppData() {
           gitLink: project.fields.gitLink,
         })) || [],
 
-      resumeUrl: fields.resume?.fields?.file?.url
-        ? "https:" + fields.resume.fields.file.url
+      resumeUrl: fields.resume.fields.resume.fields.file
+        ? "https:" + fields.resume.fields.resume.fields.file.url
         : null,
-
+       
       skills:
         fields.skills?.map((skill) => ({
           skillEntry: skill.fields.skillEntry,


### PR DESCRIPTION
Problem
Previously, the app made separate API calls to fetch projects and resume data from Contentful, which was inefficient and made content management more complex.

Solution
Refactored to use a single MainApplication content type in Contentful that contains all app data:

Created centralized fetchAppData() function that fetches everything in one API call
Maintained backward compatibility with existing fetchProjects() and fetchResumePDF() functions
Technical Changes
Updated: contentful.js - Fixed API method usage and response handling
Added: React Context (AppDataProvider) for sharing data across components
Modified: Components now use useAppData() hook instead of individual fetch calls
Benefits
✅ Single API call instead of multiple requests
✅ Better content management in Contentful CMS
✅ Improved performance and data consistency
✅ Easier to add new fields in the future