### PR TITLE
Move Contentful data fetching to Vercel serverless function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ CodeCoverage/
 TestResult.xml
 nunit-*.xml
 client/.env
+.vercel
+.env*.local

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.vercel
+.env*.local

--- a/client/api/contentful.js
+++ b/client/api/contentful.js
@@ -1,0 +1,29 @@
+import dotenv from "dotenv";
+import path from "path";
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { createClient } from "contentful";
+
+const client = createClient({
+  space: process.env.CONTENTFUL_SPACE_ID,
+  accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
+});
+
+export default async function handler(req, res) {
+  try {
+    const entries = await client.getEntries({
+      content_type: "mainApplication",
+      limit: 1,
+      include: 2,
+    });
+
+    const fields = entries.items[0]?.fields;
+    if (!fields) return res.status(404).json({ error: "No data found" });
+
+    res.setHeader("Cache-Control", "s-maxage=300, stale-while-revalidate");
+    res.status(200).json(fields);
+  } catch (err) {
+    console.error("Contentful error:", err);
+    res.status(500).json({ error: "Failed to fetch data" });
+  }
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "contentful": "^11.7.15",
+        "dotenv": "^17.4.2",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
         "react": "^19.1.1",
@@ -2639,6 +2640,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "contentful": "^11.7.15",
+    "dotenv": "^17.4.2",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
     "react": "^19.1.1",

--- a/client/src/utils/contentful.js
+++ b/client/src/utils/contentful.js
@@ -1,69 +1,51 @@
-import { createClient } from "contentful";
-
-const client = createClient({
-  space: import.meta.env.VITE_CONTENTFUL_SPACE_ID,
-  accessToken: import.meta.env.VITE_CONTENTFUL_ACCESS_TOKEN,
-});
-
 export async function fetchAppData() {
-  try {
-    const entries = await client.getEntries({
-      content_type: "mainApplication",
-      limit: 1,
-      include: 2,
-    });
-    const appEntry = entries.items[0];
+  const res = await fetch("/api/contentful");
+  if (!res.ok) throw new Error("Failed to fetch app data");
 
-    if (!appEntry) return null;
+  const fields = await res.json();
 
-    const fields = appEntry.fields;
+  return {
+    title: fields.applicationTitle,
+    profilePhoto: fields.profilePhoto
+      ? "https:" + fields.profilePhoto.fields.file.url
+      : null,
+    positions: fields.positions || [],
+    introduction: fields.introduction,
+    beyondCode: fields.beyondCode,
 
-    return {
-      title: fields.applicationTitle,
-      profilePhoto: fields.profilePhoto
-        ? "https:" + fields.profilePhoto.fields.file.url
-        : null,
-      positions: fields.positions || [],
-      introduction: fields.introduction,
-      beyondCode: fields.beyondCode,
+    projects:
+      fields.projects?.map((project) => ({
+        id: project.sys.id,
+        projectId: project.fields.id,
+        title: project.fields.title,
+        technologies: project.fields.technologies,
+        description: project.fields.description,
+        shortDescription: project.fields.shortDescription,
+        image: project.fields.image
+          ? "https:" + project.fields.image.fields.file.url
+          : null,
+        imageAltTitle: project.fields.altTitle,
+        link: project.fields.link,
+        gitLink: project.fields.gitLink,
+      })) || [],
 
-      projects:
-        fields.projects?.map((project) => ({
-          id: project.sys.id,
-          projectId: project.fields.id,
-          title: project.fields.title,
-          technologies: project.fields.technologies,
-          description: project.fields.description,
-          shortDescription: project.fields.shortDescription,
-          image: project.fields.image
-            ? "https:" + project.fields.image.fields.file.url
+    skillCategories: fields.skillCategories.map((category) => ({
+      id: category.sys.id,
+      title: category.fields.categoryTitle,
+      skills:
+        category.fields.skills?.map((skill) => ({
+          id: skill.sys.id,
+          name: skill.fields.skillEntry,
+          icon: skill.fields.skillIcon
+            ? "https:" + skill.fields.skillIcon.fields.file.url
             : null,
-          imageAltTitle: project.fields.altTitle,
-          link: project.fields.link,
-          gitLink: project.fields.gitLink,
         })) || [],
+    })),
 
-      skillCategories: fields.skillCategories.map((category) => ({
-        id: category.sys.id,
-        title: category.fields.categoryTitle,
-        skills:
-          category.fields.skills?.map((skill) => ({
-            id: skill.sys.id,
-            name: skill.fields.skillEntry,
-            icon: skill.fields.skillIcon
-              ? "https:" + skill.fields.skillIcon.fields.file.url
-              : null,
-          })) || [],
-      })),
-
-      resumeUrl: fields.resume.fields.resume.fields.file
-        ? "https:" + fields.resume.fields.resume.fields.file.url
-        : null,
-    };
-  } catch (error) {
-    console.error("Error fetching app data:", error);
-    throw error;
-  }
+    resumeUrl: fields.resume.fields.resume.fields.file
+      ? "https:" + fields.resume.fields.resume.fields.file.url
+      : null,
+  };
 }
 
 export async function fetchProjects() {


### PR DESCRIPTION
### Problem

Contentful Space ID and Access Token were exposed in the browser's network tab. The Contentful SDK was being called directly from the client, which required credentials to be bundled into the frontend JavaScript via VITE_ prefixed environment variables, making them publicly visible to anyone inspecting network requests.

### Solution

Moved all Contentful API calls to a Vercel serverless function at `api/contentful.js`. The function runs server-side, reads credentials from environment variables that are never sent to the browser, and returns plain JSON to the frontend.

The frontend `src/utils/contentful.js` now calls `/api/contentful`, a relative endpoint on the same domain, and maps the response using the same existing logic.